### PR TITLE
Update ImageRotateModule.m

### DIFF
--- a/RNImageRotate/ImageRotateModule.m
+++ b/RNImageRotate/ImageRotateModule.m
@@ -32,7 +32,7 @@ RCT_EXPORT_METHOD(rotateImage:(NSURLRequest *)imageURL
                   errorCallback:(RCTResponseErrorBlock)errorCallback)
 {
 
-  [_bridge.imageLoader loadImageWithURLRequest:imageURL callback:^(NSError *error, UIImage *image) {
+  [[_bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:imageURL callback:^(NSError *error, UIImage *image) {
     if (error) {
       errorCallback(error);
       return;


### PR DESCRIPTION
Fixed "Calling bride.imageLoader is deprecated and will not work in newer versions of RN. Please update to the moduleForClass API or turboModuleLookupDelegate API" warning (iOS)